### PR TITLE
Add Flutter Flame skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# hero_builder
+# Hero Builder Prototype
+
+This repository contains a barebones Flutter project that uses the Flame game engine. It implements the foundations of a hero-builder roguelike auto-battler inspired by **The Bazaar**.
+
+## Features
+
+- Basic `FlameGame` setup with shop and combat phases
+- Player inventory board and stash (10 tiles each)
+- Three small damage items available for purchase
+- Placeholder shop/combat logic for future expansion
+
+To build and run this project you will need Flutter installed locally. Once Flutter is installed, you can launch the game with:
+
+```bash
+flutter run
+```
+
+This project is an MVP and many features are left as TODOs throughout the code.

--- a/lib/game/hero_game.dart
+++ b/lib/game/hero_game.dart
@@ -1,0 +1,44 @@
+import 'package:flame/game.dart';
+import '../models/player.dart';
+import '../models/item.dart';
+
+enum GamePhase { shop, combat }
+
+class HeroGame extends FlameGame {
+  GamePhase phase = GamePhase.shop;
+  late Player player;
+  List<Item> shopItems = [];
+
+  @override
+  Future<void> onLoad() async {
+    player = Player();
+    _generateShopItems();
+  }
+
+  void _generateShopItems() {
+    // TODO: Replace with random generation logic
+    shopItems = [
+      DamageItem.small('Dagger', damage: 2),
+      DamageItem.small('Short Sword', damage: 3),
+      DamageItem.small('Wand', damage: 1),
+    ];
+  }
+
+  void buyItem(Item item) {
+    if (player.gold >= item.cost && player.hasInventorySpace(item.size)) {
+      player.gold -= item.cost;
+      player.addToBoard(item);
+    }
+  }
+
+  void startCombat() {
+    phase = GamePhase.combat;
+    // TODO: Implement combat resolution
+  }
+
+  void endCombat() {
+    phase = GamePhase.shop;
+    _generateShopItems();
+    // TODO: Reward gold based on outcome
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,9 @@
+import 'package:flame/game.dart';
+import 'package:flutter/material.dart';
+
+import 'game/hero_game.dart';
+
+void main() {
+  final game = HeroGame();
+  runApp(GameWidget(game: game));
+}

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -1,0 +1,18 @@
+class Item {
+  final String name;
+  final int size; // number of tiles this item occupies
+  final int damage;
+  final int cost;
+
+  const Item({
+    required this.name,
+    required this.size,
+    required this.damage,
+    required this.cost,
+  });
+}
+
+class DamageItem extends Item {
+  const DamageItem.small(String name, {required int damage})
+      : super(name: name, size: 1, damage: damage, cost: damage * 2);
+}

--- a/lib/models/player.dart
+++ b/lib/models/player.dart
@@ -1,0 +1,29 @@
+import 'item.dart';
+
+class Player {
+  int maxHealth = 30;
+  int health = 30;
+  int gold = 5;
+  static const int boardSize = 10;
+  static const int stashSize = 10;
+
+  final List<Item?> board = List<Item?>.filled(boardSize, null, growable: false);
+  final List<Item?> stash = List<Item?>.filled(stashSize, null, growable: false);
+
+  bool hasInventorySpace(int itemSize) {
+    int freeSlots = board.where((item) => item == null).length;
+    return freeSlots >= itemSize;
+  }
+
+  void addToBoard(Item item) {
+    int added = 0;
+    for (var i = 0; i < board.length && added < item.size; i++) {
+      if (board[i] == null) {
+        board[i] = item;
+        added++;
+      }
+    }
+  }
+
+  // TODO: Add methods for moving items to stash, upgrading, etc.
+}

--- a/lib/phases/combat_phase.dart
+++ b/lib/phases/combat_phase.dart
@@ -1,0 +1,2 @@
+// Placeholder for combat phase logic
+// TODO: Implement auto-battle resolution mechanics

--- a/lib/phases/shop_phase.dart
+++ b/lib/phases/shop_phase.dart
@@ -1,0 +1,2 @@
+// Placeholder for shop phase UI and logic
+// TODO: Implement user interface for buying and upgrading items

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: hero_builder
+description: A hero-builder roguelike auto-battler prototype using Flame.
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flame: ^1.10.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  assets:
+    - assets/


### PR DESCRIPTION
## Summary
- create a barebones Flutter project structure using Flame
- implement simple models for Player and Item
- add a `HeroGame` stub with shop/combat phases
- document how to run in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510dd4d9e0832ebe0fd82119d6cb05